### PR TITLE
Docker build pipeline, remove Google Maps, UI refactor

### DIFF
--- a/dbMeterClient/.dockerignore
+++ b/dbMeterClient/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+*.md

--- a/dbMeterClient/Dockerfile
+++ b/dbMeterClient/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/dbMeterClient/nginx.conf
+++ b/dbMeterClient/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+}

--- a/dbMeterClient/src/components/Comparables/comparables.scss
+++ b/dbMeterClient/src/components/Comparables/comparables.scss
@@ -1,11 +1,11 @@
 .comparable {
-  background-color: #222;
+  background-color: #1a1a1a;
   display: flex;
   justify-content: center;
   align-items: center;
+  gap: 0.5em;
   width: 100%;
   height: 2em;
-  margin-top: 1em;
   border-radius: 0.25em;
 
   &-icon {
@@ -15,26 +15,19 @@
 
     svg {
       display: block;
-      height: 1.75em;
-      width: 1.75em;
+      height: 1.5em;
+      width: 1.5em;
     }
 
     path {
-      fill: #ffffff !important;
+      fill: #555 !important;
     }
   }
 
-  &-text {}
-}
-
-@media (prefers-color-scheme: light) {
-  .comparable {
-    background-color: #f5f5f5;
-
-    &-icon {
-      path {
-        fill: #000000 !important;
-      }
-    }
+  &-text {
+    font-size: 0.8em;
+    color: #555;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 }

--- a/dbMeterClient/src/components/DBMeter/dbmeter.jsx
+++ b/dbMeterClient/src/components/DBMeter/dbmeter.jsx
@@ -1,71 +1,114 @@
 import Comparables from "../Comparables/Comparables";
 import { NumberFormatter } from "../NumberFormatter/NumberFormatter";
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import PropTypes from "prop-types";
 import "./dbmeter.scss";
 
-function Dbmeter(sensor) {
-  const last = sensor.sensor[sensor.sensor.length - 1];
-  const dbLevel = last.dbLevel;
-  const formattedDB = Math.round(last.dbLevel);
-  const time = new Date(last.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }).replace(/ AM| PM/, "");
-  last.time = time;
-  const sensorName = last.sensorName;
-  const sensorId = last.sensorId;
-  const data = sensor.sensor;
-  const font = { fill: '#ffffff', fontSize: 12, fontFamily: 'JosefinSans, Arial, sans-serif', fontWeight: '400' }
+function getDbColor(db) {
+  if (db >= 90) return '#ff1744';
+  if (db >= 85) return '#ffd740';
+  return '#00e676';
+}
 
+function Dbmeter({ sensor }) {
+  const last = sensor[sensor.length - 1];
+  const dbLevel = parseFloat(last.dbLevel);
+  const formattedDB = Math.round(dbLevel);
+  const time = new Date(last.timestamp).toLocaleTimeString([], {
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+  }).replace(/ AM| PM/, "");
+
+  const data = sensor.map(d => ({
+    ...d,
+    dbLevel: parseFloat(d.dbLevel),
+    time: new Date(d.timestamp).toLocaleTimeString([], {
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+    }).replace(/ AM| PM/, ""),
+  }));
+
+  const dbColor = getDbColor(formattedDB);
+  const vuPercent = Math.min(100, Math.max(0, ((formattedDB - 40) / 65) * 100));
+  const gradientId = `fill-${String(last.sensorId).replace(/\W/g, '')}`;
+  const axisStyle = { fill: '#444', fontSize: 10, fontFamily: 'JosefinSans, Arial, sans-serif' };
 
   return (
-    <div className="zone">
-      <div className="meter">
-        <div className="meter-header">
-          <h1 className="meter-name">{sensorName}</h1>
-          <div className="meter-header-subheader">
-            <p>Sensor ID:{sensorId}</p>
-            <p>{time}</p>
-          </div>
+    <div className="sensor-card">
+      <div className="sensor-card-header">
+        <h2 className="sensor-card-name">{last.sensorName}</h2>
+        <div className="sensor-card-meta">
+          <span>#{last.sensorId}</span>
+          <span>{time}</span>
         </div>
-        <div className="meter-output">
-          <div className="meter-output-color-ring">
-            <div className="meter-output-screen">
-              <NumberFormatter number={formattedDB} />
-              <p className="meter-output-screen-backdrop">000</p>
-            </div>
-          </div>
-        </div>
-        {dbLevel && <Comparables decibel={formattedDB} />}
       </div>
-      <div className="graph">
-        <div style={{ backgroundColor: '#777', borderRadius: '1em', boxShadow: 'inset 0 0 5px rgba(0, 0, 0, 0.2)' }}>
-          <ResponsiveContainer width={310} height={240}>
-            <AreaChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+
+      <div className="sensor-card-display">
+        <div
+          className="color-ring"
+          style={{ borderColor: dbColor, boxShadow: `0 0 20px ${dbColor}44` }}
+        >
+          <div className="lcd-screen" style={{ '--db-color': dbColor }}>
+            <NumberFormatter number={formattedDB} />
+            <p className="lcd-backdrop">000</p>
+          </div>
+        </div>
+        <span className="db-unit" style={{ color: dbColor }}>dB SPL</span>
+      </div>
+
+      <div className="vu-bar">
+        <div className="vu-bar-mask" style={{ width: `${100 - vuPercent}%` }} />
+      </div>
+
+      <Comparables decibel={formattedDB} />
+
+      <div className="sensor-chart">
+        <ResponsiveContainer width="100%" height={150}>
+          <AreaChart data={data} margin={{ top: 5, right: 5, left: -10, bottom: 0 }}>
             <defs>
-              <linearGradient id="colorUv" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#F2F700" stopOpacity={0.8}/>
-                <stop offset="95%" stopColor="#F2F700" stopOpacity={0}/>
+              {/* Y-axis gradient: hard stops at 90 dB (16.7% from top) and 85 dB (25% from top)
+                  based on fixed domain [40, 100] → range of 60 dB */}
+              <linearGradient id={`${gradientId}-stroke`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%"    stopColor="#ff1744" />
+                <stop offset="16.7%" stopColor="#ff1744" />
+                <stop offset="16.7%" stopColor="#ffd740" />
+                <stop offset="25%"   stopColor="#ffd740" />
+                <stop offset="25%"   stopColor="#00e676" />
+                <stop offset="100%"  stopColor="#00e676" />
+              </linearGradient>
+              <linearGradient id={`${gradientId}-fill`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%"    stopColor="#ff1744" stopOpacity={0.4} />
+                <stop offset="16.7%" stopColor="#ff1744" stopOpacity={0.4} />
+                <stop offset="16.7%" stopColor="#ffd740" stopOpacity={0.3} />
+                <stop offset="25%"   stopColor="#ffd740" stopOpacity={0.3} />
+                <stop offset="25%"   stopColor="#00e676" stopOpacity={0.2} />
+                <stop offset="100%"  stopColor="#00e676" stopOpacity={0}   />
               </linearGradient>
             </defs>
-              <CartesianGrid className="grid" strokeDasharray="3 3" fill="#777777" />
-              <XAxis tick={font} dataKey="time"/>
-              <YAxis tick={font} domain={[40,100]}/>
-              <Tooltip 
-                contentStyle={{ backgroundColor: '#777777', borderRadius: '1em', boxShadow: 'inset 0 0 5px rgba(0, 0, 0, 0.2)' }}
-                wrapperStyle={{ borderRadius: '1em', boxShadow: '0 0 5px 5px rgba(0, 0, 0, .25)' }}
-              />
-              <Area type="monotone" dataKey="dbLevel" stroke="#F2F700" fillOpacity={1} fill="url(#colorUv)"  isAnimationActive={false}/>
-
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1e1e1e" />
+            <XAxis tick={axisStyle} dataKey="time" />
+            <YAxis tick={axisStyle} domain={[40, 100]} />
+            <Tooltip
+              contentStyle={{ backgroundColor: '#141414', border: `1px solid ${dbColor}44`, borderRadius: '0.4em' }}
+              labelStyle={{ color: '#555' }}
+              itemStyle={{ color: dbColor }}
+            />
+            <Area
+              type="monotone"
+              dataKey="dbLevel"
+              stroke={`url(#${gradientId}-stroke)`}
+              strokeWidth={1.5}
+              fillOpacity={1}
+              fill={`url(#${gradientId}-fill)`}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );
 }
 
 Dbmeter.propTypes = {
-  decibelLevel: PropTypes.number,
-  sensor: PropTypes.array,
+  sensor: PropTypes.array.isRequired,
 };
 
 export default Dbmeter;

--- a/dbMeterClient/src/components/DBMeter/dbmeter.scss
+++ b/dbMeterClient/src/components/DBMeter/dbmeter.scss
@@ -1,130 +1,160 @@
-.meter {
-  border-radius: 1em;
-  width: 21em;
-  background: #111;
-  padding: 1em;
-  margin: 1em;
+.sensor-card {
+  background: #141414;
+  border: 1px solid #1e1e1e;
+  border-radius: 0.75em;
+  padding: 1.25em;
+  margin: 0.5em;
+  width: 20em;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9em;
+
+  @media (max-width: 480px) {
+    width: calc(100vw - 2em);
+    margin: 0.5em auto;
+  }
 
   &-header {
     display: flex;
     flex-direction: column;
-
-    h1 {
-      font-size: 2em;
-      font-weight: normal;
-    }
-
-    &-subheader {
-      display: flex;
-      justify-content: space-between;
-    }
+    gap: 0.2em;
   }
 
   &-name {
+    font-size: 1em;
+    font-weight: 300;
     margin: 0;
-    font-weight: 100;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #e0e0e0;
   }
 
-  &-output {
-    background-color: #444;
-    height: 20em;
-    width: 20em;
+  &-meta {
     display: flex;
+    justify-content: space-between;
+    font-size: 0.72em;
+    color: #444;
+    letter-spacing: 0.05em;
+  }
+
+  &-display {
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    box-shadow: 1px 1px 5px rgba(100, 100, 100, 0.5),
-      inset 4px 4px 4px rgba(255, 255, 255, 0.25);
-  }
-
-  &-output,
-  &-output * {
-    border-radius: 100%;
-    aspect-ratio: 1 / 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  &-output-color-ring {
-    background: linear-gradient(to bottom, #838eb3 75%, #002241 100%);
-    width: 12.8em;
-    height: 12.8em;
-    box-shadow: inset 5px 5px 5px rgba(100, 100, 100, 0.5);
-  }
-
-  &-output-screen {
-    box-sizing: border-box;
-    position: relative;
-    border: 2px solid grey;
-    background: #85a8c1;
-    display: flex;
-    justify-content: right;
-    align-items: center;
-    height: 12em;
-    width: 12em;
-    border-radius: 100%;
-    border: 2px solid grey;
-    z-index: 0;
-    padding: 0 0.75em;
-    box-shadow: 1px 1px 5px rgba(100, 100, 100, 0.5),
-      inset 4px 4px 4px rgba(255, 255, 255, 0.25);
-  }
-
-  &-output-screen p {
-    font-family: "DS-DIGI", "DigitalDisplay", sans-serif, monospace;
-    font-size: 6.5em;
-    font-weight: bold;
-    display: flex;
-    justify-content: end;
-  }
-
-  &-output-screen-text {
-    z-index: 2;
-  }
-
-  &-output-screen-num {
-    position: absolute;
-  }
-
-  &-output-screen-num:nth-child(2) {
-    color: #fff;
-    z-index: 2;
-  }
-
-  &-output-screen-num:nth-child(2) {
-    color: #111;
-    z-index: -1;
-  }
-
-  &-output-screen-character {
-    width: 0.5em;
-  }
-
-  &-output-screen-backdrop {
-    left: 1px;
-    color: #7375a1;
-    z-index: -1;
+    gap: 0.35em;
   }
 }
 
-.graph {
-  border-radius: 1em;
-  width: 21em;
-  background: #111;
-  padding: 1em;
-  margin: 1em;
-  height: auto;
+.color-ring {
+  width: 9em;
+  height: 9em;
+  border-radius: 50%;
+  border: 3px solid #00e676;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+  transition: border-color 0.4s ease, box-shadow 0.4s ease;
+  background: #0d0d0d;
 }
 
-@media (prefers-color-scheme: light) {
-  .meter {
-    background-color: #fff;
+.lcd-screen {
+  width: 7.5em;
+  height: 7.5em;
+  border-radius: 50%;
+  background: #0a0f0a;
+  border: 1px solid #1a2a1a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+
+  .meter-output-screen-num {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2;
   }
 
-  .graph {
-    background-color: #fff;
+  p.meter-output-screen-character {
+    font-family: "DS-DIGI", monospace;
+    font-size: 3.5em;
+    font-weight: bold;
+    color: var(--db-color, #00e676);
+    margin: 0;
+    width: 0.55em;
+    display: flex;
+    justify-content: center;
+    line-height: 1;
+    transition: color 0.4s ease;
   }
+
+  .lcd-backdrop {
+    font-family: "DS-DIGI", monospace;
+    font-size: 3.5em;
+    font-weight: bold;
+    color: #0c1a0c;
+    margin: 0;
+    position: absolute;
+    z-index: 1;
+    line-height: 1;
+    letter-spacing: 0.04em;
+  }
+}
+
+.db-unit {
+  font-size: 0.65em;
+  letter-spacing: 0.3em;
+  font-weight: 300;
+  text-transform: uppercase;
+  transition: color 0.4s ease;
+}
+
+.vu-bar {
+  height: 0.45em;
+  border-radius: 0.25em;
+  position: relative;
+  background: linear-gradient(
+    to right,
+    #00e676  0%,
+    #00e676  69.2%,
+    #ffd740  69.2%,
+    #ffd740  76.9%,
+    #ff1744  76.9%,
+    #ff1744  100%
+  );
+
+  // segment dividers over the full track
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 0.25em;
+    background: repeating-linear-gradient(
+      to right,
+      transparent     0px,
+      transparent     5px,
+      rgba(0,0,0,0.3) 5px,
+      rgba(0,0,0,0.3) 6px
+    );
+    z-index: 1;
+  }
+
+  // dark mask slides in from the right to hide unlit portion
+  &-mask {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background: #141414;
+    border-radius: 0 0.25em 0.25em 0;
+    transition: width 0.25s ease;
+    z-index: 2;
+  }
+}
+
+.sensor-chart {
+  margin-top: 0.25em;
 }

--- a/dbMeterClient/src/components/TheRack/TheRack.jsx
+++ b/dbMeterClient/src/components/TheRack/TheRack.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import Dbmeter from "../DBMeter/dbmeter";
 import mqtt from "mqtt";
-import { PlayCircleOutlined } from "@ant-design/icons";
 import "./therack.scss";
+
 const MAX_NUMBER_OF_DATA_POINTS = 600;
 const DISTANCE_BETWEEN_SAMPLES_MILLIS = 2000;
+
 function TheRack() {
   const [sensorData, setSensorData] = useState([]);
 
@@ -16,77 +17,66 @@ function TheRack() {
       connectTimeout: 30000,
       reconnectPeriod: 1000,
     };
-    const position = {lat: 53.54992, lng: 10.00678};
     const client = mqtt.connect(import.meta.env.VITE_MQTT_URL, mqttOptions);
 
     client.on("connect", () => {
       client.subscribe(topic, (err) => {
-        if (!err) {
-          console.log("subscribed");
-        }
+        if (!err) console.log("subscribed to", topic);
       });
     });
+
     client.on("message", (topic, message) => {
       const jsonMessage = JSON.parse(message);
-      // legacy support for old messages
-      if (jsonMessage.timestamp === undefined) {
-        jsonMessage.timestamp = jsonMessage.timeStamp;
-      }
-      if (jsonMessage.sensorName === undefined) {
-        jsonMessage.sensorName = jsonMessage.sensor_name;
-      }
-      // ignore messages with dbLevel less than 40
-      if (jsonMessage.dbLevel<40) {
-        return
-      }
+
+      // legacy field name support
+      if (jsonMessage.timestamp === undefined) jsonMessage.timestamp = jsonMessage.timeStamp;
+      if (jsonMessage.sensorName === undefined) jsonMessage.sensorName = jsonMessage.sensor_name;
+
+      // normalise dbLevel to a number
+      jsonMessage.dbLevel = parseFloat(jsonMessage.dbLevel);
+
+      if (jsonMessage.dbLevel < 40) return;
+
       setSensorData((prevSensorData) => {
-        // Check if sensor with the same sensorId already exists
-        const existingSensorIndex = prevSensorData.findIndex(
-          (sensorArray) => sensorArray[0].sensorId === jsonMessage.sensorId
+        const existingIndex = prevSensorData.findIndex(
+          (arr) => arr[0].sensorId === jsonMessage.sensorId
         );
-        if (existingSensorIndex !== -1) {
-          // Add the new datapoint to the sensor data array.
+
+        if (existingIndex !== -1) {
           const updatedSensorData = [...prevSensorData];
-          let newArray = updatedSensorData[existingSensorIndex];
-          // Remove data points that are too close to each other
-          if (newArray.length > 2 && newArray[newArray.length - 2].timestamp + DISTANCE_BETWEEN_SAMPLES_MILLIS >= newArray[newArray.length - 1].timestamp) {
-            let first = newArray.pop();
-            let second = newArray.pop();
-            if (first.dbLevel > second.dbLevel) {
-              newArray.push(first);
-            } else {
-              newArray.push(second);
-            }
+          let arr = updatedSensorData[existingIndex];
+
+          // drop whichever of the last two points is quieter when they're too close together
+          if (arr.length > 2 && arr[arr.length - 2].timestamp + DISTANCE_BETWEEN_SAMPLES_MILLIS >= arr[arr.length - 1].timestamp) {
+            const latest = arr.pop();
+            const prev   = arr.pop();
+            arr.push(latest.dbLevel > prev.dbLevel ? latest : prev);
           }
-          // always add the new data point -- we will remove it later if it is too close to the previous point
-          newArray.push(jsonMessage);
-          // Remove oldest data point if number of data points exceeds the maximum
-          if (newArray.length > MAX_NUMBER_OF_DATA_POINTS) {
-            newArray.shift();
-          }
-          updatedSensorData[existingSensorIndex] = [...newArray];
+
+          arr.push(jsonMessage);
+          if (arr.length > MAX_NUMBER_OF_DATA_POINTS) arr.shift();
+
+          updatedSensorData[existingIndex] = [...arr];
           return updatedSensorData;
         } else {
-          // Add new sensor data if it doesn't exist
           return [...prevSensorData, [jsonMessage]];
         }
       });
     });
 
-    return () => {
-      client.end();
-    };
-  }, []); // Empty dependency array to run effect only once
+    return () => client.end();
+  }, []);
 
   return (
     <div className="the-rack">
-      <button>
-        <PlayCircleOutlined />
-      </button>
       <div className="the-rack-sensors">
-        {sensorData.map((sensor) => (
-          <Dbmeter key={sensor[0].sensorId} sensor={sensor} />
-        ))}
+        {sensorData.length === 0 ? (
+          <p className="the-rack-empty">Waiting for sensors&hellip;</p>
+        ) : (
+          sensorData.map((sensor) => (
+            <Dbmeter key={sensor[0].sensorId} sensor={sensor} />
+          ))
+        )}
       </div>
     </div>
   );

--- a/dbMeterClient/src/components/TheRack/TheRack.jsx
+++ b/dbMeterClient/src/components/TheRack/TheRack.jsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from "react";
 import Dbmeter from "../DBMeter/dbmeter";
 import mqtt from "mqtt";
 import { PlayCircleOutlined } from "@ant-design/icons";
-import {APIProvider, Map} from '@vis.gl/react-google-maps';
-import SensorMapMarker from "../SensorMapMarker/SensorMapMarker";
 import "./therack.scss";
 const MAX_NUMBER_OF_DATA_POINTS = 600;
 const DISTANCE_BETWEEN_SAMPLES_MILLIS = 2000;
@@ -80,40 +78,17 @@ function TheRack() {
     };
   }, []); // Empty dependency array to run effect only once
 
-  const position ={
-      lat: parseFloat(import.meta.env.VITE_GOOGLE_MAPS_LAT),
-      lng: parseFloat(import.meta.env.VITE_GOOGLE_MAPS_LONG)
-    };
-
   return (
-    <>
-      <div className="the-rack">
-        <button>
-          <PlayCircleOutlined />
-        </button>
-        <div className="the-rack-sensors">
-          {sensorData.map((sensor) => (
-            <Dbmeter key={sensor[0].sensorId} sensor={sensor} />
-          ))}
-        </div>
+    <div className="the-rack">
+      <button>
+        <PlayCircleOutlined />
+      </button>
+      <div className="the-rack-sensors">
+        {sensorData.map((sensor) => (
+          <Dbmeter key={sensor[0].sensorId} sensor={sensor} />
+        ))}
       </div>
-      <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}  libraries={['marker']}>
-        <Map
-          style={{width: '90vw', height: '40vh'}}
-          defaultCenter={position}
-          defaultZoom={20}
-          disableDefaultUI={true}
-          mapId={import.meta.env.VITE_GOOGLE_MAPS_ID}
-        >
-            {sensorData.map((sensor) => {
-              if (sensor.at(-1).latitude && sensor.at(-1).longitude) {
-                return <SensorMapMarker key={sensor.at(-1).sensorId} sensor={sensor.at(-1)} />
-              }
-            }
-            )}
-        </Map>
-      </APIProvider>
-    </>
+    </div>
   );
 }
 

--- a/dbMeterClient/src/components/TheRack/therack.scss
+++ b/dbMeterClient/src/components/TheRack/therack.scss
@@ -1,15 +1,20 @@
 .the-rack {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  padding: 1em;
 
   &-sensors {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
   }
-}
 
-@media (prefers-color-scheme: light) {
-  .the-rack {
-    background-color: #f5f5f5;
+  &-empty {
+    color: #333;
+    font-size: 0.85em;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-top: 4em;
   }
 }

--- a/dbMeterClient/src/index.css
+++ b/dbMeterClient/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: dark;
+  color: #e0e0e0;
+  background-color: #0d0d0d;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -15,54 +15,36 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: #00e676;
+  text-decoration: none;
 }
 a:hover {
-  color: #535bf2;
+  color: #69f0ae;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
+h1, h2 {
   line-height: 1.1;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+  border-radius: 6px;
+  border: 1px solid #333;
+  padding: 0.5em 1em;
+  font-size: 0.9em;
   font-weight: 500;
   font-family: inherit;
   background-color: #1a1a1a;
+  color: #e0e0e0;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: border-color 0.2s;
+  letter-spacing: 0.05em;
 }
 button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  border-color: #00e676;
 }

--- a/dbMeterClient/src/routes/Root.jsx
+++ b/dbMeterClient/src/routes/Root.jsx
@@ -1,16 +1,11 @@
 import "../style/Style.scss";
 import TheRack from "../components/TheRack/TheRack";
+
 function App() {
   return (
     <div className="app">
-
-      <h1 className="app-header">DB Meter</h1>
+      <h1 className="app-header">ACC dB Meter</h1>
       <TheRack />
-      <ul>
-        <li>
-          <a href="debug">Debug</a>
-        </li>
-      </ul>
     </div>
   );
 }

--- a/dbMeterClient/src/style/Style.scss
+++ b/dbMeterClient/src/style/Style.scss
@@ -1,6 +1,18 @@
 @import url("../style/fonts.css");
 
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .app-header {
   font-weight: 100;
-  padding: 0em 0.5em;
+  font-size: 1.3em;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  padding: 0.8em 1.25em;
+  color: #e0e0e0;
+  border-bottom: 1px solid #1e1e1e;
+  margin: 0;
 }

--- a/sensor/esp32-s3-DevKitC/data/secrets/config.json
+++ b/sensor/esp32-s3-DevKitC/data/secrets/config.json
@@ -7,7 +7,7 @@
     "units":"feet",
     "x_loc":0,
     "y_loc":0,
-    "mqtt_server": "192.168.1.187",
+    "mqtt_server": "10.1.10.15",
     "mqtt_port": 1885,
     "mqtt_username": "admin",
     "mqtt_password": "admin",


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile (Node build → nginx serve) for `dbMeterClient`
- Add `nginx.conf` with SPA routing and gzip
- Remove `@vis.gl/react-google-maps` dependency entirely
- Full UI refactor: dark theme, dynamic gauges, VU bar, responsive layout
- Update ESP32 `config.json`: `mqtt_server` updated to production broker IP

## UI Changes

- **Dark mode locked** — removed all light mode media queries
- **Unified sensor card** — merged separate meter + graph boxes into one card
- **Dynamic color ring** — border and glow transitions green → yellow → red based on live dB level
- **VU bar** — full-width segmented gradient track; dark mask reveals correct zone color at the live level (no red tip at low volumes)
- **Chart gradients** — Y-axis hard stops at 85 dB and 90 dB so peaks are colored by zone
- **Color thresholds**: green <85 dB, yellow 85–89 dB, red 90+ dB
- **Responsive** — cards go full-width on mobile
- **Empty state** — "Waiting for sensors…" when no sensors connected
- Normalise `dbLevel` to float at ingest (ESP32 publishes it as a string)

## Test plan

- [ ] `docker build` completes without errors
- [ ] App loads at container IP on port 80
- [ ] MQTT connects to broker and receives sensor messages
- [ ] Gauge ring, VU bar, and chart all respond to live dB data
- [ ] Color zones change correctly at 85 dB and 90 dB thresholds
- [ ] `/debug` route still accessible