### PR TITLE
Docs: clean up and rewrite all README files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,23 +1,3 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a name="readme-top"></a>
-<!--
-*** Thanks for checking out the Best-README-Template. If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
-
-
-
-<!-- PROJECT SHIELDS -->
-<!--
-*** I'm using markdown "reference style" links for readability.
-*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
-*** See the bottom of this document for the declaration of the reference variables
-*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
-*** https://www.markdownguide.org/basic-syntax/#reference-style-links
--->
 [![Contributors][contributors-shield]][contributors-url]
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
@@ -25,206 +5,171 @@
 [![MIT License][license-shield]][license-url]
 [![LinkedIn][linkedin-shield]][linkedin-url]
 
-
-
-<!-- PROJECT LOGO -->
 <br />
 <div align="center">
   <a href="https://github.com/SR-Coder/accDbMeter">
-    <img src="./sensor/DBSensor/favicon2.png" alt="Logo" width="80" height="80">
+    <img src="./SC.png" alt="ACC dB Meter" width="480">
   </a>
 
-<h3 align="center">ACC DB Meter</h3>
+  <h3 align="center">ACC dB Meter</h3>
 
   <p align="center">
-    A simple app using React, Mosquitto, and Micropython to create a multi station db meter.
+    A multi-station decibel monitoring system built with React, Mosquitto MQTT, and MicroPython/C++.
     <br />
-    <a href="https://github.com/SR-Coder/accdbmeter"><strong>Explore the docs »</strong></a>
-    <br />
-    <br />
-    <!-- <a href="https://github.com/SR-Coder/accDbMeter">View Demo</a>
-    · -->
     <a href="https://github.com/SR-Coder/accDbMeter/issues">Report Bug</a>
-    ·
+    &nbsp;·&nbsp;
     <a href="https://github.com/SR-Coder/accDbMeter/issues">Request Feature</a>
   </p>
 </div>
 
+---
 
+## About
 
-<!-- TABLE OF CONTENTS -->
-<details>
-  <summary>Table of Contents</summary>
-  <ol>
-    <li>
-      <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#built-with">Built With</a></li>
-      </ul>
-    </li>
-    <li>
-      <a href="#getting-started">Getting Started</a>
-      <ul>
-        <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation">Installation</a></li>
-      </ul>
-    </li>
-    <li><a href="#usage">Usage</a></li>
-    <li><a href="#roadmap">Roadmap</a></li>
-    <li><a href="#contributing">Contributing</a></li>
-    <li><a href="#license">License</a></li>
-    <li><a href="#contact">Contact</a></li>
-    <li><a href="#acknowledgments">Acknowledgments</a></li>
-  </ol>
-</details>
+ACC dB Meter is a real-time audio level monitoring system designed for multi-venue or multi-zone environments. Wireless sensors measure ambient decibel levels and publish readings over MQTT. A React dashboard subscribes to the broker and displays live per-sensor gauges, VU bars, and historical charts — all colour-coded by dB zone.
 
+**Sensors** publish to a Mosquitto MQTT broker over Wi-Fi. The **React client** connects via WebSocket and renders a card per sensor, updating in real time.
 
+---
 
-<!-- ABOUT THE PROJECT -->
-## About The Project
+## Built With
 
-[![Watch the video](https://github.com/SR-Coder/images/blob/05f440764e748dc62ee17c6884361ea359455889/SC.png)](https://youtu.be/0ZKzztuRJgg)
-
-
-
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-### Built With
-
-<!-- * [![Next][Next.js]][Next-url] -->
-* [![React][React.js]][React-url]
-* [![Micropython][micropython.dev]][micropython-url]
+* [![React][React.js]][React-url] + [Vite](https://vitejs.dev)
 * [![Mosquitto][mosquittoB]][mosquitto-url]
+* [![Micropython][micropython.dev]][micropython-url] (Raspberry Pi Pico W)
+* [Arduino / PlatformIO](https://platformio.org) (ESP32-S3)
 
-<!-- * [![Vue][Vue.js]][Vue-url] -->
-<!-- * [![Angular][Angular.io]][Angular-url]
-* [![Svelte][Svelte.dev]][Svelte-url]
-* [![Laravel][Laravel.com]][Laravel-url]
-* [![Bootstrap][Bootstrap.com]][Bootstrap-url]
-* [![JQuery][JQuery.com]][JQuery-url] -->
+---
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+## Architecture
 
+```
+Sensor (Pico W / ESP32-S3)
+  └─ Wi-Fi ──► Mosquitto broker  (port 1885, MQTT)
+                      │
+                      └─ WebSocket (port 8885) ──► React client (browser)
+```
 
+Each sensor publishes a JSON message to the `DBMeter` topic:
 
-<!-- GETTING STARTED -->
+```json
+{
+  "sensorId": 57243727616732,
+  "sensorName": "Back of Church",
+  "dbLevel": 74,
+  "timestamp": 1708206580764
+}
+```
+
+---
+
 ## Getting Started
-
-To get a local copy up and running follow these simple example steps.
 
 ### Prerequisites
 
-This is an example of how to list things you need to use the software and how to install them.
-* npm
-  ```sh
-  npm install npm@latest -g
-  ```
+- [Docker](https://docs.docker.com/get-docker/) — for the broker and client
+- [Node.js 20+](https://nodejs.org) — for local development only
+- A flashed Raspberry Pi Pico W or ESP32-S3 with the sensor firmware
 
-### Installation
+### Running with Docker
 
+The recommended way to run the full stack is via Docker.
 
-1. Clone the repo
-   ```sh
-   git clone https://github.com/SR-Coder/accDbMeter.git
-   ```
-1. Navigate to the dbMeterClient folder
-   ```sh
-  cd dbMeterClient
-  ```
-1. Install NPM packages
-   ```sh
-   npm install
-   ```
-1. Install mosquitto
-  ```sh
-  brew install mosquitto
-  ```
+**1. Mosquitto broker**
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+```sh
+docker run -d \
+  --name mosquitto \
+  --network br0 \
+  -v /path/to/appdata/mosquitto/config:/mosquitto/config \
+  eclipse-mosquitto:2
+```
 
+The config at `/mosquitto/config/mosquitto.conf` should define two listeners:
 
+```
+listener 1885 0.0.0.0
+allow_anonymous true
 
-<!-- USAGE EXAMPLES -->
-## Usage
+listener 8885 0.0.0.0
+protocol websockets
+allow_anonymous true
+```
 
-TBD
+**2. React client**
 
-<!-- _For more examples, please refer to the [Documentation](https://example.com)_ -->
+```sh
+# From the repo root
+docker build -t acc-dbmeter-client:latest ./dbMeterClient
+docker run -d \
+  --name acc-dbmeter-client \
+  --network br0 \
+  acc-dbmeter-client:latest
+```
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+The client is then available at the container's assigned IP on port 80.
 
+### Local Development
 
+```sh
+cd dbMeterClient
+cp .env.sample .env.local
+# Edit .env.local — set VITE_MQTT_URL to your broker's WebSocket address
+npm install
+npm run dev
+```
 
-<!-- ROADMAP -->
+---
+
+## Sensor Configuration
+
+See [`sensor/README.md`](sensor/README.md) for firmware setup and initial Wi-Fi provisioning.
+
+Once a sensor is on the network, browse to its IP address to configure:
+- **MQTT broker address and port** (default port: `1885`)
+- **Sensor name** displayed on the dashboard
+- **Publish rate**
+
+---
+
 ## Roadmap
 
-- [ ] Build Front End
-- [ ] Simple Auth for front end (to protect settings or config)
-- [ ] Design Code for Sensor
-- [ ] Use Mosquitto Broker to share data
-- [ ] Visualize Audio Levels in a venue
-- [ ] Build Docker Environment for easy installation
+- [x] React + Vite front-end client
+- [x] Sensor firmware — Raspberry Pi Pico W (MicroPython)
+- [x] Sensor firmware — ESP32-S3 (Arduino / PlatformIO)
+- [x] Mosquitto MQTT broker integration
+- [x] Multi-station real-time dB visualisation
+- [x] Docker deployment
+- [x] Dark mode UI with dynamic VU bar and colour-coded gauges
+- [ ] Location map (Leaflet / OpenStreetMap)
+- [ ] Authentication for sensor configuration dashboard
 
-See the [open issues](https://github.com/SR-Coder/accDbMeter/issues) for a full list of proposed features (and known issues).
+---
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- CONTRIBUTING -->
 ## Contributing
 
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Commit your changes
+4. Push to the branch (`git push origin feature/my-feature`)
+5. Open a pull request
 
-If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
-Don't forget to give the project a star! Thanks again!
+---
 
-1. Fork the Project
-2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- LICENSE -->
 ## License
 
-Distributed under the MIT License. See `LICENSE.txt` for more information.
+Distributed under the MIT License. See [`LICENSE.txt`](LICENSE.txt) for details.
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+---
 
-
-
-<!-- CONTACT -->
 ## Contact
 
-Jim Reeder -  info@jcrlabs.com
+Jim Reeder — info@jcrlabs.com
 
-Project Link: [https://github.com/SR-Coder/accDbMeter](https://github.com/SR-Coder/accDbMeter)
+Project: [https://github.com/SR-Coder/accDbMeter](https://github.com/SR-Coder/accDbMeter)
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+---
 
-
-
-<!-- ACKNOWLEDGMENTS -->
-## Acknowledgments
-
-<!-- * []()
-* []()
-* []() -->
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- MARKDOWN LINKS & IMAGES -->
-<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [contributors-shield]: https://img.shields.io/github/contributors/SR-Coder/accDbMeter.svg?style=for-the-badge
 [contributors-url]: https://github.com/SR-Coder/accDbMeter/graphs/contributors
 [forks-shield]: https://img.shields.io/github/forks/SR-Coder/accDbMeter.svg?style=for-the-badge
@@ -237,24 +182,9 @@ Project Link: [https://github.com/SR-Coder/accDbMeter](https://github.com/SR-Cod
 [license-url]: https://github.com/SR-Coder/accDbMeter/blob/master/LICENSE.txt
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 [linkedin-url]: https://linkedin.com/in/james-reeder-55582366/
-[product-screenshot]: images/screenshot.png
 [mosquitto-url]: https://mosquitto.org/
-[mosquittoB]:https://mosquitto.org/images/mosquitto-text-side-28.png
-[micropython.dev]:https://micropython.org/static/img/Mlogo_138wh.png
-[micropython-url]:https://micropython.org
-[Next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
-[Next-url]: https://nextjs.org/
+[mosquittoB]: https://mosquitto.org/images/mosquitto-text-side-28.png
+[micropython.dev]: https://micropython.org/static/img/Mlogo_138wh.png
+[micropython-url]: https://micropython.org
 [React.js]: https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB
 [React-url]: https://reactjs.org/
-[Vue.js]: https://img.shields.io/badge/Vue.js-35495E?style=for-the-badge&logo=vuedotjs&logoColor=4FC08D
-[Vue-url]: https://vuejs.org/
-[Angular.io]: https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white
-[Angular-url]: https://angular.io/
-[Svelte.dev]: https://img.shields.io/badge/Svelte-4A4A55?style=for-the-badge&logo=svelte&logoColor=FF3E00
-[Svelte-url]: https://svelte.dev/
-[Laravel.com]: https://img.shields.io/badge/Laravel-FF2D20?style=for-the-badge&logo=laravel&logoColor=white
-[Laravel-url]: https://laravel.com
-[Bootstrap.com]: https://img.shields.io/badge/Bootstrap-563D7C?style=for-the-badge&logo=bootstrap&logoColor=white
-[Bootstrap-url]: https://getbootstrap.com
-[JQuery.com]: https://img.shields.io/badge/jQuery-0769AD?style=for-the-badge&logo=jquery&logoColor=white
-[JQuery-url]: https://jquery.com 

--- a/dbMeterClient/README.md
+++ b/dbMeterClient/README.md
@@ -1,64 +1,98 @@
-# React + Vite
+# ACC dB Meter — Client
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + Vite front-end for the ACC dB Meter system. Connects to a Mosquitto MQTT broker via WebSocket and displays real-time decibel readings from one or more wireless sensors.
 
-Currently, two official plugins are available:
+---
 
-- Please use functional components
+## Running with Docker (recommended)
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```sh
+# From this directory
+docker build -t acc-dbmeter-client:latest .
+docker run -d \
+  --name acc-dbmeter-client \
+  --restart unless-stopped \
+  --network br0 \
+  acc-dbmeter-client:latest
+```
 
-## Running the app in dev mode
+The app is served by nginx on port 80 at the container's assigned IP.
 
-copy the .env.sample file to .env.local
+---
 
-`npm run dev`
+## Local Development
 
+**1. Configure environment**
 
-## Mosquitto
-Install mosquitto using:
-`brew install mosquitto`
+```sh
+cp .env.sample .env.local
+```
 
-run up the server using the simple config file:
-`mosquitto -c ./local.mosquitto.conf`
+Edit `.env.local` and set `VITE_MQTT_URL` to your broker's WebSocket address:
 
-In the webapp, click on connect and then subscribe.
+```
+VITE_MQTT_URL=ws://<broker-ip>:8885
+```
 
-Then we can send messages using:
-`mosquitto_pub -h 127.0.0.1 -p 1885 -t dbMeter/dbLevel -f sample_messages/green_low.json`
+**2. Install and run**
 
-With the defaults in the webapp you should see the messages appear.
+```sh
+npm install
+npm run dev
+```
 
-## Running test messages
-From the dbMeterClient directory run.
-`node sample_messages/send_messages.js`
+---
 
-It's a simple file that contains the list of sensors to send from and the interval
-for how frequently they are sent at the top of the file. Feel free to edit to add
-more sensors, or change the interval.
+## Simulating Sensor Data
 
-## MQTT integration
+To test the UI without physical sensors, use the included message sender from this directory:
 
-This is based on the guide here:
-https://mpolinowski.github.io/docs/Development/Javascript/2021-06-01--mqtt-with-reactjs/2021-06-01/
+```sh
+node sample_messages/send_messages.js
+```
 
-Like the guide, the MQTT React components have been pulled in from here:
-https://github.com/emqx/MQTT-Client-Examples
-specifically this version:
-https://github.com/emqx/MQTT-Client-Examples/tree/ccf475eec8ec7f03d6ec9e75c462fdb53bb4438d/mqtt-client-React/src/components
+Edit the top of `send_messages.js` to adjust the sensor list and publish interval.
 
-## Google Maps
+You can also publish a single test message directly:
 
-Google Maps integration is done using the 
-visgl Google Maps library -- https://visgl.github.io/react-google-maps
-https://visgl.github.io/react-google-maps/examples
+```sh
+mosquitto_pub -h <broker-ip> -p 1885 -t DBMeter -f sample_messages/green_low.json
+```
 
-It gives a great springboard for some very cool visualisations and effects.
+---
 
-### TODO
-[] Auth - https://mosquitto.org/documentation/authentication-methods/
-[] Admin pages?
-[] Styling of the maps
-[] resizing of dbMeters and the graph to fit in maps nicely
-[] explore heatmaps
+## MQTT Message Format
+
+The client subscribes to the `DBMeter` topic and expects JSON in this shape:
+
+```json
+{
+  "sensorId": 57243727616732,
+  "sensorName": "Back of Church",
+  "dbLevel": 74,
+  "timestamp": 1708206580764
+}
+```
+
+The client also accepts legacy field names (`sensor_name`, `timeStamp`) for backwards compatibility with older firmware.
+
+---
+
+## dB Colour Zones
+
+| Range | Colour | Meaning |
+|-------|--------|---------|
+| < 85 dB | Green | Safe |
+| 85 – 89 dB | Yellow | Caution |
+| 90 dB + | Red | Danger |
+
+These thresholds are reflected in the ring border, VU bar, and chart line.
+
+---
+
+## Routes
+
+| Path | Description |
+|------|-------------|
+| `/` | Main dashboard — live sensor cards |
+| `/debug` | Raw MQTT connection and message inspector |

--- a/sensor/README.md
+++ b/sensor/README.md
@@ -1,59 +1,116 @@
-# Raspberry Pi Pico W
+# ACC dB Meter — Sensor Firmware
 
-This template provides a light weight Wi-Fi Manager using MicroPython. Development starting with esp32 and the teensy4.1 with esp32 wifi over spi.  While the micropython webserver works adquately, the implementation with micropython is slow, the mqtt and webserver sockets have unexpected interactions that lead to negative effects.    
+Firmware for the wireless decibel sensor nodes. Two hardware targets are supported:
 
+| Directory | Hardware | Language |
+|-----------|----------|----------|
+| `RPiPicoW/` | Raspberry Pi Pico W | MicroPython |
+| `esp32-s3-DevKitC/` | ESP32-S3 DevKitC | Arduino / PlatformIO |
 
+Both targets connect to a Wi-Fi network, read decibel levels over I²C, and publish readings to a Mosquitto MQTT broker on the `DBMeter` topic.
 
+---
 
+## Initial Setup
 
-## Initializing the Sensor 
-- clone the repo
-- open the code in either VSCode using the PyMakr Plugin or Thonny IDE
-- Have MicroPython set up on your RPPW
-- Transfer the code from the ide of your choice to the RPPW
-- Hard Reset the device or turn it off and back on again
-- Connect to the `ACCDBMeter-WifiManager` station
-- Once connected navigate to `192.168.4.1:8080`
-- Select your prefered local network and enter the network password
-- KNOWN ISSUES - the Wifi manager will record open networks and will attempt to connect to them before the network that was specified in the previous steps
-- Re-connect to your local wifi networks and then search for your device on your router.
+### Raspberry Pi Pico W
+
+**Prerequisites**
+- MicroPython flashed to the Pico W
+- [VSCode + PyMakr plugin](https://marketplace.visualstudio.com/items?itemName=pycom.Pymakr) or [Thonny IDE](https://thonny.org)
+
+**Steps**
+1. Clone the repo and open the `RPiPicoW/` folder in your IDE
+2. Transfer all files to the Pico W
+3. Hard reset the device
+4. Connect to the `ACCDBMeter-WifiManager` access point
+5. Navigate to `192.168.4.1:8080` and select your Wi-Fi network
+6. The device will reboot, join the network, and appear on your router
+
+> **Note:** The Wi-Fi manager will attempt to connect to any previously saved network before the one just configured. If the device does not appear on your network, power cycle it once more.
+
+### ESP32-S3 DevKitC
+
+**Prerequisites**
+- [PlatformIO](https://platformio.org) (VSCode extension or CLI)
+
+**Steps**
+1. Open the `esp32-s3-DevKitC/` folder in PlatformIO
+2. Edit `data/secrets/config.json` with your MQTT broker address and sensor name (see [Configuration](#configuration) below)
+3. Upload the filesystem: `pio run --target uploadfs`
+4. Build and upload firmware: `pio run --target upload`
+5. On first boot the device enters access point mode — connect and configure Wi-Fi via the captive portal
+
+---
+
+## Configuration
+
+Once a sensor is on the network, browse to its IP address to configure it via the web dashboard. All settings are stored on the device and persist across reboots.
+
+| Setting | Description |
+|---------|-------------|
+| **Sensor Name** | Display name shown on the dashboard |
+| **MQTT Broker Address** | IP or hostname of the Mosquitto broker |
+| **MQTT Port** | Default: `1885` |
+| **Publish Rate** | How frequently readings are sent (ms) |
+
+The ESP32 can also be pre-configured by editing `data/secrets/config.json` before flashing:
+
+```json
+{
+  "sensor_name": "Front of House",
+  "mqtt_server": "192.168.1.100",
+  "mqtt_port": 1885,
+  "mqtt_rate": 100
+}
+```
+
+---
+
+## Status LED (ESP32-S3)
+
+The onboard RGB LED indicates connection state:
+
+| Colour | State |
+|--------|-------|
+| Blue (flashing) | Access point mode — awaiting Wi-Fi configuration |
+| Red (solid) | Wi-Fi connected, MQTT disconnected |
+| Yellow (flashing) | Wi-Fi connected, attempting MQTT connection |
+| Green (flashing) | Fully connected and publishing |
+| Red (flashing) | Connected but publishing paused (`/mqttStop`) |
+
+---
+
+## MQTT Message Format
+
+```json
+{
+  "sensorId": 57243727616732,
+  "sensorName": "Front of House",
+  "dbLevel": 74,
+  "timestamp": 1708206580764
+}
+```
+
+Topic: `DBMeter`
+Broker port: `1885` (standard MQTT)
+
+---
 
 ## Wi-Fi Manager
-A Wi-Fi Manager library has been added to MicroPython, therefore the end user can now connect to the accespoint on inital power up and select an available SSID and enter a password.  This allows end user configuration
 
-### General Flow:
-- On initial power up (after code is uploaded) the RPPW performs as an access point allowing users to connect to basic web server
-- User configures the RPPW to connect to their prefered wireless network
-- Network credentials are then saved to a file in the RPPW long term storage
-- The Wifi manager loop will end returning to the main loop prompting the device to connect to the network that was specified
-- The device is now on the network and ready to be configured via the web ui. 
+On first boot, the device creates a `ACCDBMeter-WifiManager` access point. Connecting to it presents a simple web page where you can select an available SSID and enter the password. Credentials are saved to persistent storage and used on all subsequent boots.
 
-This is based directly on this guide:
-https://microcontrollerslab.com/raspberry-pi-pico-w-wi-fi-manager-web-server/
+Based on the [Raspberry Pi Pico W Wi-Fi Manager](https://microcontrollerslab.com/raspberry-pi-pico-w-wi-fi-manager-web-server/) guide.
 
-## MQTT integration
-WIP
+---
 
-### TODO
-- [ ] Require SSID's with a Password no open networks
-- [x] Build a config file for ease of use
-- [x] Write is logged out on startup.
-- [x] Build Sensor Config Page
-    - [x] Add server address
-    - [x] Add server port
-    - [x] Add device unique ID
-    - [x] Add validations
-- [ ] Add ability to change passwords and default ssid
-- [x] Ensure auth data is writen to secrets file not user config file
-- [x] Require password to enter the Config page
-- [ ] Connect config file to mqtt stuff
-- [x] Cookie Based Session
-- [ ] Interface with sensor
-- [ ] Interface with MQTT
-- [ ] Send Data to MQTT
-- [ ] Multi-Threading
+## Roadmap
 
-## Version 2
-- [x] Address Security Concerns:
-    - [x] Add session or token to tie login to individual user
-- [ ] Convert structure to a "Class" object
+- [x] Wi-Fi manager for network provisioning
+- [x] Web dashboard for sensor configuration
+- [x] Cookie-based authentication for the config dashboard
+- [x] MQTT publish with configurable rate
+- [x] Unique sensor ID per device
+- [ ] Restrict Wi-Fi manager to password-protected networks only
+- [ ] OTA firmware update support


### PR DESCRIPTION
## Summary

- **Root README** — removed boilerplate template, added architecture diagram, rewrote installation instructions for Docker, updated roadmap to reflect current state
- **Client README** — removed Vite template content and Google Maps section, added MQTT message format reference, dB colour zone table, and routes table
- **Sensor README** — fixed typos, updated MQTT section, added ESP32 status LED table, pre-config JSON example, cleaned up roadmap

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All links resolve correctly
- [ ] Architecture diagram displays as expected