### PR TITLE
Docs: update hero screenshot to new dark UI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@
 <br />
 <div align="center">
   <a href="https://github.com/SR-Coder/accDbMeter">
-    <img src="./SC.png" alt="ACC dB Meter" width="480">
+    <img src="./screenshot.png" alt="ACC dB Meter" width="480">
   </a>
 
   <h3 align="center">ACC dB Meter</h3>


### PR DESCRIPTION
Replaces the old `SC.png` hero image with the new `screenshot.png` showing the updated dark mode dashboard.